### PR TITLE
Fix case sensivity paths

### DIFF
--- a/OCCSonarQube/OCCSonarQube.sln
+++ b/OCCSonarQube/OCCSonarQube.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 15.0.28307.329
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SonarQube", "SonarQube\SonarQube.vcxproj", "{19007FBB-9040-43AA-BCF2-F3D84F07B302}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Plugin", "..\..\OpenCppCoverage\Plugin\Plugin.vcxproj", "{2F439508-07E0-4084-9614-1A42BDE8ED9A}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Plugin", "..\OpenCppCoverage\Plugin\Plugin.vcxproj", "{2F439508-07E0-4084-9614-1A42BDE8ED9A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/OCCSonarQube/SonarQube/SonarQube.vcxproj
+++ b/OCCSonarQube/SonarQube/SonarQube.vcxproj
@@ -173,7 +173,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\OpenCppCoverage\Plugin\Plugin.vcxproj">
+    <ProjectReference Include="..\..\OpenCppCoverage\Plugin\Plugin.vcxproj">
       <Project>{2f439508-07e0-4084-9614-1a42bde8ed9a}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/OCCSonarQube/SonarQube/stdafx.h
+++ b/OCCSonarQube/SonarQube/stdafx.h
@@ -10,7 +10,7 @@
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 // Windows Header Files
 #include <windows.h>
-
+#include <shellapi.h>
 
 
 // reference additional headers your program requires here


### PR DESCRIPTION
Hello,
I found a problem with uploading scans to my SonarQube server. I spotted that my files are all lowercase and sonar-scanner doesn't detect the line covered. This fix will change all paths to be the same as they are with case sensitivity.
For example:
C:\test\mycode.cpp to C:\Test\MYCode.cpp

I also updated OCC submodule to 0.9.8.0 release version.

Thanks,
Andrzej Huk